### PR TITLE
Update to 2.2.25

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: udunits2-{{ version }}.tar.gz
   url: https://github.com/Unidata/UDUNITS-2/archive/v{{ version }}.tar.gz
-  sha256:
+  sha256: b566e0634f5d2d03001f50e216684eca0c62dd017b53bdfd58ff61c6cd450523
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,14 +1,13 @@
-{% set version = "2.2.23" %}
-{% set commit = "d3540a8077f83b87490bec71191c8d3060a01ee1" %}
+{% set version = "2.2.25" %}
 
 package:
   name: udunits2
   version: {{ version }}
 
 source:
-  fn: {{ commit }}.tar.gz
-  url: https://github.com/Unidata/UDUNITS-2/archive/{{ commit }}.tar.gz
-  sha256: 26c893864288d98fe876c43dc1239a8ff2d07fdd4ae027d2d30700a77a4ae1d8
+  fn: udunits2-{{ version }}.tar.gz
+  url: https://github.com/Unidata/UDUNITS-2/archive/v{{ version }}.tar.gz
+  sha256:
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,9 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: udunits2-{{ version }}.tar.gz
   url: https://github.com/Unidata/UDUNITS-2/archive/v{{ version }}.tar.gz
-  sha256: b566e0634f5d2d03001f50e216684eca0c62dd017b53bdfd58ff61c6cd450523
+  sha256: a57092cc3bb17e4afd07a8728f1562cd40f38e0f399e6a12b19584d9e41cdd8f
 
 build:
   number: 1


### PR DESCRIPTION
```
2.2.25	2017-01-25T10:59:53-0700
    Added "stamp-vti" and "version.texi" to ".gitignore".

2.2.24	2017-01-24T14:42:49-0700
    Added (against my better judgment) the unit "ppv". Use "1" instead and call
    the physical quantity "volume fraction".

    Fixed utCalendar() in the UDUNITS-1 interface returning 60 seconds.
```