### PR TITLE
use scripts to define UDUNITS2_XML_PATH

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -20,3 +20,12 @@ if [[ $(uname) == Darwin ]]; then
     cp ${RECIPE_DIR}/patchbinary.py ${PREFIX}/
     echo ${PREFIX} > ${PREFIX}/build_prefix.a
 fi
+
+# Make sure ENV variables and set
+ACTIVATE_DIR=$PREFIX/etc/conda/activate.d
+DEACTIVATE_DIR=$PREFIX/etc/conda/deactivate.d
+mkdir -p $ACTIVATE_DIR
+mkdir -p $DEACTIVATE_DIR
+
+cp $RECIPE_DIR/scripts/activate.sh $ACTIVATE_DIR/udunits2-activate.sh
+cp $RECIPE_DIR/scripts/deactivate.sh $DEACTIVATE_DIR/udunits2-deactivate.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b7149332e80fb306f3041451a9b7c9237f7ccde85dbedcb234d2b4cccf987711
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: True  # [win and py35]
   # Abandon py27+win support, like libnetcdf.
@@ -33,7 +33,7 @@ requirements:
 test:
   commands:
     - udunits2 -h
-    - udunits2 -H meter -W miles  # [not win]
+    - udunits2 -H meter -W miles
     - conda inspect linkages -p $PREFIX $PKG_NAME  # [not win]
     - conda inspect objects -p $PREFIX $PKG_NAME  # [osx]
 

--- a/recipe/scripts/activate.bat
+++ b/recipe/scripts/activate.bat
@@ -1,0 +1,8 @@
+:: Store existing env vars and set to this conda env
+:: so other installs don't pollute the environment.
+
+@if defined UDUNITS2_XML_PATH (
+    set "_CONDA_SET_UDUNITS2_XML_PATH=%UDUNITS2_XML_PATH%"
+)
+
+@set "UDUNITS2_XML_PATH=%CONDA_PREFIX%\Library\share\udunits\udunits2.xml"

--- a/recipe/scripts/activate.sh
+++ b/recipe/scripts/activate.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Store existing env vars and set to this conda env
+# so other installs don't pollute the environment.
+
+if [[ -n "$UDUNITS2_XML_PATH" ]]; then
+    export _CONDA_SET_UDUNITS2_XML_PATH=$UDUNITS2_XML_PATH
+fi
+
+# On Linux the share data is in $CONDA_PREFIX/share, but
+# Windows keeps it in $CONDA_PREFIX/Library/share
+if [ -d $CONDA_PREFIX/share/udunits ]; then
+    export UDUNITS2_XML_PATH=$CONDA_PREFIX/share/udunits/udunits2.xml
+elif [ -d $CONDA_PREFIX/Library/share/udunits ]; then
+    export UDUNITS2_XML_PATH=$CONDA_PREFIX/Library/share/udunits/udunits2.xml
+fi

--- a/recipe/scripts/bld.bat
+++ b/recipe/scripts/bld.bat
@@ -28,15 +28,3 @@ copy lib\udunits2.dll %SCRIPTS%\udunits2.dll || exit 1
 copy ..\lib\*.h %LIBRARY_INC%\ || exit 1
 copy lib\*.exp %LIBRARY_LIB%\ || exit 1
 copy lib\*.lib %LIBRARY_LIB%\ || exit 1
-
-set ACTIVATE_DIR=%PREFIX%\etc\conda\activate.d
-set DEACTIVATE_DIR=%PREFIX%\etc\conda\deactivate.d
-mkdir %ACTIVATE_DIR%
-mkdir %DEACTIVATE_DIR%
-
-copy %RECIPE_DIR%\scripts\activate.bat %ACTIVATE_DIR%\udunits2-activate.bat || exit 1
-copy %RECIPE_DIR%\scripts\deactivate.bat %DEACTIVATE_DIR%\udunits2-deactivate.bat  || exit 1
-
-:: Copy unix shell activation scripts, needed by Windows Bash users
-copy %RECIPE_DIR%\scripts\activate.sh %ACTIVATE_DIR%\udunits2-activate.sh || exit 1
-copy %RECIPE_DIR%\scripts\deactivate.sh %DEACTIVATE_DIR%\udunits2-deactivate.sh || exit 1

--- a/recipe/scripts/deactivate.bat
+++ b/recipe/scripts/deactivate.bat
@@ -1,0 +1,7 @@
+@REM Restore previous env vars if they were set.
+
+@set "UDUNITS2_XML_PATH="
+@if defined _CONDA_SET_UDUNITS2_XML_PATH (
+  set "UDUNITS2_XML_PATH=%_CONDA_SET_UDUNITS2_XML_PATH%"
+  set "_CONDA_SET_UDUNITS2_XML_PATH="
+)

--- a/recipe/scripts/deactivate.sh
+++ b/recipe/scripts/deactivate.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Restore previous env vars if they were set
+
+unset UDUNITS2_XML_PATH
+if [[ -n "$_CONDA_SET_UDUNITS2_XML_PATH" ]]; then
+    export UDUNITS2_XML_PATH=$_CONDA_SET_UDUNITS2_XML_PATH
+    unset _CONDA_SET_UDUNITS2_XML_PATH
+fi


### PR DESCRIPTION
@pelson can you take a look at this? It should help with the `cf_units` issue in https://github.com/conda-forge/cf_units-feedstock/pull/14#issuecomment-390923177.

This is a workaround for https://github.com/conda-forge/udunits2-feedstock/issues/18. A possible permanent fix would be https://github.com/Unidata/UDUNITS-2/pull/63